### PR TITLE
fastbootd: Allow using kernel commits to pass SafetyNet

### DIFF
--- a/fastboot/device/utility.cpp
+++ b/fastboot/device/utility.cpp
@@ -206,7 +206,24 @@ bool GetDeviceLockStatus() {
     if (!android::base::ReadFileToString("/proc/cmdline", &cmdline)) {
         return true;
     }
-    return cmdline.find("androidboot.verifiedbootstate=green") != std::string::npos;
+    // Always return unlocked if androidboot.verifiedbootstate is missing
+    // from the userspace kernel command line so kernel commits like:
+    // proc: Remove verifiedbootstate flag from /proc/cmdline
+    // can be used to pass the SafetyNet CTS check.
+    //
+    // Otherwise when using fastbootd the device will think it's locked
+    // because androidboot.verifiedbootstate=orange isn't there.
+    bool noverifiedbootstate =
+        cmdline.find("androidboot.verifiedbootstate") == std::string::npos;
+    bool verifiedbootstategreen =
+        cmdline.find("androidboot.verifiedbootstate=green") != std::string::npos;
+    if (noverifiedbootstate) {
+        return false;
+    } else if (verifiedbootstategreen) {
+        return false;
+    } else {
+        return cmdline.find("androidboot.verifiedbootstate=orange") == std::string::npos;
+    }
 }
 
 bool UpdateAllPartitionMetadata(FastbootDevice* device, const std::string& super_name,


### PR DESCRIPTION
When using kernel commits to pass SafetyNet and CTS like:

- proc: Remove verifiedbootstate flag from /proc/cmdline
- proc: Set androidboot.verifiedbootstate=green

fastbootd returns the device as locked when flashing images or resizing partitions when flashing because it can't find androidboot.verifiedbootstate=orange in the kernel command line letting it know it's safe to flash.

So if androidboot.verifiedbootstate is missing from the kernel command line or if is returning verifiedbootstate=green report the device as unlocked.

Change-Id: I56712f374ea26397ea5a183cfe100cf92e21d531
Signed-off-by: Pranav <npv12@iitbbs.ac.in>