### PR TITLE
debuggerd: use jemalloc by default and allow opt-in to scudo (4/4)

### DIFF
--- a/debuggerd/Android.bp
+++ b/debuggerd/Android.bp
@@ -257,7 +257,7 @@ cc_library_static {
             cflags: ["-DROOT_POSSIBLE"],
         },
 
-        malloc_not_svelte: {
+        malloc_use_scudo: {
             cflags: ["-DUSE_SCUDO"],
             whole_static_libs: ["libscudo"],
             srcs: ["libdebuggerd/scudo.cpp"],

--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -46,6 +46,8 @@
 
 #define POWER_SUPPLY_SUBSYSTEM "power_supply"
 #define POWER_SUPPLY_SYSFS_PATH "/sys/class/" POWER_SUPPLY_SUBSYSTEM
+#define SYSFS_BATTERY_CURRENT "/sys/class/power_supply/battery/current_now"
+#define SYSFS_BATTERY_VOLTAGE "/sys/class/power_supply/battery/voltage_now"
 #define FAKE_BATTERY_CAPACITY 42
 #define FAKE_BATTERY_TEMPERATURE 424
 #define MILLION 1.0e6
@@ -520,19 +522,13 @@ void BatteryMonitor::updateValues(void) {
                     KLOG_WARNING(LOG_TAG, "%s: Unknown power supply type\n",
                                  mChargerNames[i].string());
             }
-            path.clear();
-            path.appendFormat("%s/%s/current_max", POWER_SUPPLY_SYSFS_PATH,
-                              mChargerNames[i].string());
-            int ChargingCurrent =
-                    (access(path.string(), R_OK) == 0) ? getIntField(path) : 0;
 
-            path.clear();
-            path.appendFormat("%s/%s/voltage_max", POWER_SUPPLY_SYSFS_PATH,
-                              mChargerNames[i].string());
+            int ChargingCurrent =
+                  (access(SYSFS_BATTERY_CURRENT, R_OK) == 0) ? abs(getIntField(String8(SYSFS_BATTERY_CURRENT))) : 0;
 
             int ChargingVoltage =
-                (access(path.string(), R_OK) == 0) ? getIntField(path) :
-                DEFAULT_VBUS_VOLTAGE;
+                  (access(SYSFS_BATTERY_VOLTAGE, R_OK) == 0) ? getIntField(String8(SYSFS_BATTERY_VOLTAGE)) :
+                   DEFAULT_VBUS_VOLTAGE;
 
             double power = ((double)ChargingCurrent / MILLION) *
                            ((double)ChargingVoltage / MILLION);

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -935,14 +935,14 @@ static void workaround_snet_properties() {
     // Hide all sensitive props 
     LOG(INFO) << "snet: Hiding sensitive props";
     for (int i = 0; snet_prop_key[i]; ++i) {
-        PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
+        PropertySetNoSocket(snet_prop_key[i], snet_prop_value[i], &error);
     }
 
     // Extra pops
     std::string build_flavor_key = "ro.build.flavor";
     std::string build_flavor_value = android::base::GetProperty(build_flavor_key, "");
     build_flavor_value = android::base::StringReplace(build_flavor_value, "userdebug", "user", false);
-    PropertySet(build_flavor_key, build_flavor_value, &error);
+    PropertySetNoSocket(build_flavor_key, build_flavor_value, &error);
 
     // Restore the normal property override security after safetynet props have been set
     weaken_prop_override_security = false;

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -861,45 +861,55 @@ static void load_override_properties() {
 }
 
 static const char *snet_prop_key[] = {
-	"ro.boot.vbmeta.device_state",
-	"ro.boot.verifiedbootstate",
-	"ro.boot.flash.locked",
-	"ro.boot.selinux",
-	"ro.boot.veritymode",
-	"ro.boot.warranty_bit",
-	"ro.warranty_bit",
-	"ro.debuggable",
-	"ro.secure",
-	"ro.build.type",
-	"ro.build.keys",
-	"ro.build.tags",
-	"ro.system.build.tags",
-	"ro.vendor.boot.warranty_bit",
-	"ro.vendor.warranty_bit",
-	"vendor.boot.vbmeta.device_state",
-	"vendor.boot.verifiedbootstate",
-	NULL
+    "ro.boot.vbmeta.device_state",
+    "ro.boot.verifiedbootstate",
+    "ro.boot.flash.locked",
+    "ro.boot.selinux",
+    "ro.boot.veritymode",
+    "ro.boot.warranty_bit",
+    "ro.warranty_bit",
+    "ro.debuggable",
+    "ro.secure",
+    "ro.build.type",
+    "ro.system.build.type",
+    "ro.system_ext.build.type",
+    "ro.vendor.build.type",
+    "ro.product.build.type",
+    "ro.odm.build.type",
+    "ro.build.keys",
+    "ro.build.tags",
+    "ro.system.build.tags",
+    "ro.vendor.boot.warranty_bit",
+    "ro.vendor.warranty_bit",
+    "vendor.boot.vbmeta.device_state",
+    "vendor.boot.verifiedbootstate",
+    NULL
 };
 
 static const char *snet_prop_value[] = {
-	"locked", // ro.boot.vbmeta.device_state
-	"green", // ro.boot.verifiedbootstate
-	"1", // ro.boot.flash.locked
-	"enforcing", // ro.boot.selinux
-	"enforcing", // ro.boot.veritymode
-	"0", // ro.boot.warranty_bit
-	"0", // ro.warranty_bit
-	"0", // ro.debuggable
-	"1", // ro.secure
-	"user", // ro.build.type
-	"release-keys", // ro.build.keys
-	"release-keys", // ro.build.tags
-	"release-keys", // ro.system.build.tags
-	"0", // ro.vendor.boot.warranty_bit
-	"0", // ro.vendor.warranty_bit
-	"locked", // vendor.boot.vbmeta.device_state
-	"green", // vendor.boot.verifiedbootstate
-	NULL
+    "locked", // ro.boot.vbmeta.device_state
+    "green", // ro.boot.verifiedbootstate
+    "1", // ro.boot.flash.locked
+    "enforcing", // ro.boot.selinux
+    "enforcing", // ro.boot.veritymode
+    "0", // ro.boot.warranty_bit
+    "0", // ro.warranty_bit
+    "0", // ro.debuggable
+    "1", // ro.secure
+    "user", // ro.build.type
+    "user", // ro.system.build.type
+    "user", // ro.system_ext.build.type
+    "user", // ro.vendor.build.type
+    "user", // ro.product.build.type
+    "user", // ro.odm.build.type
+    "release-keys", // ro.build.keys
+    "release-keys", // ro.build.tags
+    "release-keys", // ro.system.build.tags
+    "0", // ro.vendor.boot.warranty_bit
+    "0", // ro.vendor.warranty_bit
+    "locked", // vendor.boot.vbmeta.device_state
+    "green", // vendor.boot.verifiedbootstate
+    NULL
 };
 
 static void workaround_snet_properties() {
@@ -908,15 +918,21 @@ static void workaround_snet_properties() {
     // Weaken property override security to set safetynet props
     weaken_prop_override_security = true;
 
-	std::string error;
+    std::string error;
 
-	// Hide all sensitive props if not eng build
+    // Hide all sensitive props if not eng build
     if (build_type != "eng") {
-	    LOG(INFO) << "snet: Hiding sensitive props";
-	    for (int i = 0; snet_prop_key[i]; ++i) {
+        LOG(INFO) << "snet: Hiding sensitive props";
+        for (int i = 0; snet_prop_key[i]; ++i) {
             PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
-	    }
+        }
     }
+
+    // Extra pops
+    std::string build_flavor_key = "ro.build.flavor";
+    std::string build_flavor_value = android::base::GetProperty(build_flavor_key, "");
+    build_flavor_value = android::base::StringReplace(build_flavor_value, "userdebug", "user", false);
+    PropertySet(build_flavor_key, build_flavor_value, &error);
 
     // Restore the normal property override security after safetynet props have been set
     weaken_prop_override_security = false;

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -934,7 +934,7 @@ static void workaround_snet_properties() {
     // Bail out if this is recovery, fastbootd, or anything other than a normal boot.
     // fastbootd, in particular, needs the real values so it can allow flashing on
     // unlocked bootloaders.
-    if (!isNormalBoot) {
+    if (!isNormalBoot || IsRecoveryMode()) {
         return;
     }
 
@@ -1332,7 +1332,9 @@ void PropertyLoadBootDefaults() {
     update_sys_usb_config();
 
     // Workaround SafetyNet
-    workaround_snet_properties();
+    if (!IsRecoveryMode()) {
+        workaround_snet_properties();
+    }
 }
 
 bool LoadPropertyInfoFromFile(const std::string& filename,

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -860,6 +860,8 @@ static void load_override_properties() {
     }
 }
 
+constexpr auto ANDROIDBOOT_MODE = "androidboot.mode"sv;
+
 static const char *snet_prop_key[] = {
     "ro.boot.vbmeta.device_state",
     "ro.boot.verifiedbootstate",
@@ -915,17 +917,41 @@ static const char *snet_prop_value[] = {
 static void workaround_snet_properties() {
     std::string build_type = android::base::GetProperty("ro.build.type", "");
 
+    // Check whether this is a normal boot, and whether the bootloader is actually locked
+    auto isNormalBoot = true; // no prop = normal boot
+    // This runs before keys are set as props, so we need to process them ourselves.
+    ImportKernelCmdline([&](const std::string& key, const std::string& value) {
+        if (key == ANDROIDBOOT_MODE && value != "normal") {
+            isNormalBoot = false;
+        }
+    });
+    ImportBootconfig([&](const std::string& key, const std::string& value) {
+        if (key == ANDROIDBOOT_MODE && value != "normal") {
+            isNormalBoot = false;
+        }
+    });
+
+    // Bail out if this is recovery, fastbootd, or anything other than a normal boot.
+    // fastbootd, in particular, needs the real values so it can allow flashing on
+    // unlocked bootloaders.
+    if (!isNormalBoot) {
+        return;
+    }
+
+    // Exit if eng build
+    if (build_type == "eng") {
+        return;
+    }
+
     // Weaken property override security to set safetynet props
     weaken_prop_override_security = true;
 
     std::string error;
 
-    // Hide all sensitive props if not eng build
-    if (build_type != "eng") {
-        LOG(INFO) << "snet: Hiding sensitive props";
-        for (int i = 0; snet_prop_key[i]; ++i) {
-            PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
-        }
+    // Hide all sensitive props 
+    LOG(INFO) << "snet: Hiding sensitive props";
+    for (int i = 0; snet_prop_key[i]; ++i) {
+        PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
     }
 
     // Extra pops

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -921,12 +921,12 @@ static void workaround_snet_properties() {
     auto isNormalBoot = true; // no prop = normal boot
     // This runs before keys are set as props, so we need to process them ourselves.
     ImportKernelCmdline([&](const std::string& key, const std::string& value) {
-        if (key == ANDROIDBOOT_MODE && value != "normal" && value != "reboot") {
+        if (key == ANDROIDBOOT_MODE && value != "normal") {
             isNormalBoot = false;
         }
     });
     ImportBootconfig([&](const std::string& key, const std::string& value) {
-        if (key == ANDROIDBOOT_MODE && value != "normal" && value != "reboot") {
+        if (key == ANDROIDBOOT_MODE && value != "normal") {
             isNormalBoot = false;
         }
     });

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -860,6 +860,50 @@ static void load_override_properties() {
     }
 }
 
+static const char *snet_prop_key[] = {
+	"ro.boot.vbmeta.device_state",
+	"ro.boot.verifiedbootstate",
+	"ro.boot.flash.locked",
+	"ro.boot.selinux",
+	"ro.boot.veritymode",
+	"ro.boot.warranty_bit",
+	"ro.warranty_bit",
+	"ro.debuggable",
+	"ro.secure",
+	"ro.build.type",
+	"ro.build.keys",
+	"ro.build.tags",
+	"ro.system.build.tags",
+	NULL
+};
+
+static const char *snet_prop_value[] = {
+	"locked", // ro.boot.vbmeta.device_state
+	"green", // ro.boot.verifiedbootstate
+	"1", // ro.boot.flash.locked
+	"enforcing", // ro.boot.selinux
+	"enforcing", // ro.boot.veritymode
+	"0", // ro.boot.warranty_bit
+	"0", // ro.warranty_bit
+	"0", // ro.debuggable
+	"1", // ro.secure
+	"user", // ro.build.type
+	"release-keys", // ro.build.keys
+	"release-keys", // ro.build.tags
+	"release-keys", // ro.system.build.tags
+	NULL
+};
+
+static void workaround_snet_properties() {
+	std::string error;
+	LOG(INFO) << "snet: Hiding sensitive props";
+
+	// Hide all sensitive props
+	for (int i = 0; snet_prop_key[i]; ++i) {
+		PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
+	}
+}
+
 // If the ro.product.[brand|device|manufacturer|model|name] properties have not been explicitly
 // set, derive them from ro.product.${partition}.* properties
 static void property_initialize_ro_product_props() {
@@ -1226,6 +1270,9 @@ void PropertyLoadBootDefaults() {
     weaken_prop_override_security = false;
 
     update_sys_usb_config();
+
+    // Workaround SafetyNet
+    workaround_snet_properties();
 
     // Restore the normal property override security after init extension is executed
     weaken_prop_override_security = false;

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -860,8 +860,6 @@ static void load_override_properties() {
     }
 }
 
-constexpr auto ANDROIDBOOT_MODE = "androidboot.mode"sv;
-
 static const char *snet_prop_key[] = {
     "ro.boot.vbmeta.device_state",
     "ro.boot.verifiedbootstate",
@@ -917,24 +915,10 @@ static const char *snet_prop_value[] = {
 static void workaround_snet_properties() {
     std::string build_type = android::base::GetProperty("ro.build.type", "");
 
-    // Check whether this is a normal boot, and whether the bootloader is actually locked
-    auto isNormalBoot = true; // no prop = normal boot
-    // This runs before keys are set as props, so we need to process them ourselves.
-    ImportKernelCmdline([&](const std::string& key, const std::string& value) {
-        if (key == ANDROIDBOOT_MODE && value != "normal") {
-            isNormalBoot = false;
-        }
-    });
-    ImportBootconfig([&](const std::string& key, const std::string& value) {
-        if (key == ANDROIDBOOT_MODE && value != "normal") {
-            isNormalBoot = false;
-        }
-    });
-
     // Bail out if this is recovery, fastbootd, or anything other than a normal boot.
     // fastbootd, in particular, needs the real values so it can allow flashing on
     // unlocked bootloaders.
-    if (!isNormalBoot) {
+    if (IsRecoveryMode()) {
         return;
     }
 

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -934,7 +934,7 @@ static void workaround_snet_properties() {
     // Bail out if this is recovery, fastbootd, or anything other than a normal boot.
     // fastbootd, in particular, needs the real values so it can allow flashing on
     // unlocked bootloaders.
-    if (!isNormalBoot || IsRecoveryMode()) {
+    if (!isNormalBoot) {
         return;
     }
 
@@ -1332,9 +1332,7 @@ void PropertyLoadBootDefaults() {
     update_sys_usb_config();
 
     // Workaround SafetyNet
-    if (!IsRecoveryMode()) {
-        workaround_snet_properties();
-    }
+    workaround_snet_properties();
 }
 
 bool LoadPropertyInfoFromFile(const std::string& filename,

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -903,16 +903,20 @@ static const char *snet_prop_value[] = {
 };
 
 static void workaround_snet_properties() {
+    std::string build_type = android::base::GetProperty("ro.build.type", "");
+
     // Weaken property override security to set safetynet props
     weaken_prop_override_security = true;
 
 	std::string error;
-	LOG(INFO) << "snet: Hiding sensitive props";
 
-	// Hide all sensitive props
-	for (int i = 0; snet_prop_key[i]; ++i) {
-		PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
-	}
+	// Hide all sensitive props if not eng build
+    if (build_type != "eng") {
+	    LOG(INFO) << "snet: Hiding sensitive props";
+	    for (int i = 0; snet_prop_key[i]; ++i) {
+            PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
+	    }
+    }
 
     // Restore the normal property override security after safetynet props have been set
     weaken_prop_override_security = false;

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -921,12 +921,12 @@ static void workaround_snet_properties() {
     auto isNormalBoot = true; // no prop = normal boot
     // This runs before keys are set as props, so we need to process them ourselves.
     ImportKernelCmdline([&](const std::string& key, const std::string& value) {
-        if (key == ANDROIDBOOT_MODE && value != "normal") {
+        if (key == ANDROIDBOOT_MODE && value != "normal" && value != "reboot") {
             isNormalBoot = false;
         }
     });
     ImportBootconfig([&](const std::string& key, const std::string& value) {
-        if (key == ANDROIDBOOT_MODE && value != "normal") {
+        if (key == ANDROIDBOOT_MODE && value != "normal" && value != "reboot") {
             isNormalBoot = false;
         }
     });

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -874,6 +874,10 @@ static const char *snet_prop_key[] = {
 	"ro.build.keys",
 	"ro.build.tags",
 	"ro.system.build.tags",
+	"ro.vendor.boot.warranty_bit",
+	"ro.vendor.warranty_bit",
+	"vendor.boot.vbmeta.device_state",
+	"vendor.boot.verifiedbootstate",
 	NULL
 };
 
@@ -891,6 +895,10 @@ static const char *snet_prop_value[] = {
 	"release-keys", // ro.build.keys
 	"release-keys", // ro.build.tags
 	"release-keys", // ro.system.build.tags
+	"0", // ro.vendor.boot.warranty_bit
+	"0", // ro.vendor.warranty_bit
+	"locked", // vendor.boot.vbmeta.device_state
+	"green", // vendor.boot.verifiedbootstate
 	NULL
 };
 

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -903,6 +903,9 @@ static const char *snet_prop_value[] = {
 };
 
 static void workaround_snet_properties() {
+    // Weaken property override security to set safetynet props
+    weaken_prop_override_security = true;
+
 	std::string error;
 	LOG(INFO) << "snet: Hiding sensitive props";
 
@@ -910,6 +913,9 @@ static void workaround_snet_properties() {
 	for (int i = 0; snet_prop_key[i]; ++i) {
 		PropertySet(snet_prop_key[i], snet_prop_value[i], &error);
 	}
+
+    // Restore the normal property override security after safetynet props have been set
+    weaken_prop_override_security = false;
 }
 
 // If the ro.product.[brand|device|manufacturer|model|name] properties have not been explicitly
@@ -1281,9 +1287,6 @@ void PropertyLoadBootDefaults() {
 
     // Workaround SafetyNet
     workaround_snet_properties();
-
-    // Restore the normal property override security after init extension is executed
-    weaken_prop_override_security = false;
 }
 
 bool LoadPropertyInfoFromFile(const std::string& filename,

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -128,6 +128,8 @@ struct PropertyAuditData {
     const char* name;
 };
 
+static bool weaken_prop_override_security = false;
+
 static int PropertyAuditCallback(void* data, security_class_t /*cls*/, char* buf, size_t len) {
     auto* d = reinterpret_cast<PropertyAuditData*>(data);
 
@@ -397,8 +399,8 @@ static std::optional<uint32_t> PropertySet(const std::string& name, const std::s
 
     prop_info* pi = (prop_info*)__system_property_find(name.c_str());
     if (pi != nullptr) {
-        // ro.* properties are actually "write-once".
-        if (StartsWith(name, "ro.")) {
+        // ro.* properties are actually "write-once", unless the system decides to
+        if (StartsWith(name, "ro.") && !weaken_prop_override_security) {
             *error = "Read-only property was already set";
             return {PROP_ERROR_READ_ONLY_PROPERTY};
         }
@@ -1207,6 +1209,9 @@ void PropertyLoadBootDefaults() {
         }
     }
 
+    // Weaken property override security during execution of the vendor init extension
+    weaken_prop_override_security = true;
+
     // Update with vendor-specific property runtime overrides
     vendor_load_properties();
 
@@ -1217,7 +1222,13 @@ void PropertyLoadBootDefaults() {
     property_initialize_ro_cpu_abilist();
     property_initialize_ro_vendor_api_level();
 
+    // Restore the normal property override security after init extension is executed
+    weaken_prop_override_security = false;
+
     update_sys_usb_config();
+
+    // Restore the normal property override security after init extension is executed
+    weaken_prop_override_security = false;
 }
 
 bool LoadPropertyInfoFromFile(const std::string& filename,

--- a/libprocessgroup/profiles/task_profiles.json
+++ b/libprocessgroup/profiles/task_profiles.json
@@ -521,7 +521,7 @@
           "Params":
           {
             "Controller": "cpuset",
-            "Path": "system-background"
+            "Path": "foreground"
           }
         }
       ]
@@ -534,7 +534,7 @@
           "Params":
           {
             "Controller": "cpuset",
-            "Path": "system-background"
+            "Path": "foreground"
           }
         }
       ]

--- a/rootdir/etc/hosts
+++ b/rootdir/etc/hosts
@@ -1,2 +1,5 @@
 127.0.0.1       localhost
 ::1             ip6-localhost
+127.0.0.1 ota.googlezip.net
+127.0.0.1 ota-cache1.googlezip.net
+127.0.0.1 ota-cache2.googlezip.net

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -1096,10 +1096,9 @@ on zygote-start && property:ro.crypto.state=encrypted && property:ro.crypto.type
     start zygote
     start zygote_secondary
 
+# Tweak background writeout
 on boot && property:ro.config.low_ram=true
-    # Tweak background writeout
     write /proc/sys/vm/dirty_expire_centisecs 200
-    write /proc/sys/vm/dirty_background_ratio  5
 
 on boot
     # basic network init
@@ -1115,6 +1114,8 @@ on boot
     # parameters to match how it is managing things.
     write /proc/sys/vm/overcommit_memory 1
     write /proc/sys/vm/min_free_order_shift 4
+    write /proc/sys/vm/dirty_background_bytes 52428800
+    write /proc/sys/vm/dirty_bytes 209715200
 
     # System server manages zram writeback
     chown root system /sys/block/zram0/idle


### PR DESCRIPTION
Since we have switched to jemalloc (bionic).

Change-Id: Ie89f9a7be4e965abf346402084a2a2d032771d3e